### PR TITLE
fix: remove Message container from SettingDrawer

### DIFF
--- a/example/AntDesign.Pro.Layout.Wasm/App.razor
+++ b/example/AntDesign.Pro.Layout.Wasm/App.razor
@@ -8,3 +8,4 @@
         </LayoutView>
     </NotFound>
 </Router>
+<AntContainer />

--- a/src/SettingDrawer/SettingDrawer.razor
+++ b/src/SettingDrawer/SettingDrawer.razor
@@ -90,7 +90,6 @@
         </div>
     </ChildContent>
 </Drawer>
-<Message />
 
 <link type="text/css" rel="stylesheet" id="theme-style" href="@_url" @ref="_linkRef">
 @code


### PR DESCRIPTION
to fix the [issues 38](https://github.com/ant-design-blazor/ant-design-pro-blazor/issues/38) of ant-design-pro-blazor